### PR TITLE
Save bitmovin dir to asset in database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ jspm_packages
 
 # Serverless directories
 .serverless
+.webpack
 
 # ENV
 .env


### PR DESCRIPTION
After bitmovin encodes a video, it sends back a response. We parse the new encoding folder value from the response, and the original video location from the message that triggered the lambda. We use the video location to find the Asset in our database, and update the livestream_dir column with the new bitmovin folder attribute.

Tags: bitmovin, assets, enterprise portal, livestreams